### PR TITLE
Python: Add test for tricky module member for type-tracking

### DIFF
--- a/python/ql/test/experimental/dataflow/typetracking/mymodule.py
+++ b/python/ql/test/experimental/dataflow/typetracking/mymodule.py
@@ -2,3 +2,6 @@ x = tracked # $tracked
 
 def func():
     return tracked # $tracked
+
+z = tracked # $tracked
+some_func(z) # $tracked

--- a/python/ql/test/experimental/dataflow/typetracking/test.py
+++ b/python/ql/test/experimental/dataflow/typetracking/test.py
@@ -54,6 +54,7 @@ def test_import():
     mymodule.x # $tracked
     y = mymodule.func() # $tracked
     y # $tracked
+    mymodule.z # $tracked
 
 # ------------------------------------------------------------------------------
 

--- a/python/ql/test/experimental/dataflow/typetracking/tracked.expected
+++ b/python/ql/test/experimental/dataflow/typetracking/tracked.expected
@@ -1,0 +1,1 @@
+| test.py:57:16:57:25 | Comment # $tracked | Missing result:tracked= |


### PR DESCRIPTION
I tracked this down in real project `https://lgtm.com/projects/g/grantcurell/rock-frontend` since we couldn't figure out that the `app` imported [here](https://github.com/grantcurell/rock-frontend/blob/804425f0e37ffd7b0b9c8e6d3fa76b31bd52a981/backend/app/archive_controller.py#L6) is actually the `app` defined [here](https://github.com/grantcurell/rock-frontend/blob/804425f0e37ffd7b0b9c8e6d3fa76b31bd52a981/backend/app/__init__.py#L52).

I used this QL snippet to figure out what was going on

```ql
from DataFlow::AttrRead read, ControlFlowNode obj, ModuleValue mv, Module m, EssaVariable v
where
  read.getAttributeName() = "z" and
  obj = read.getObject().asCfgNode() and
  obj.pointsTo() = mv and
  m = mv.getScope() and
  v.getAUse() = m.getANormalExit()
select m, v.getName(), v.getDefinition(), v
```